### PR TITLE
Split mapping and sync redis queues

### DIFF
--- a/src/infra/redis_queue.py
+++ b/src/infra/redis_queue.py
@@ -8,9 +8,9 @@ from rq.queue import Queue
 MAX_JOB_TIMEOUT = 60 * 60 * 24
 
 
-def get_redis_queue():
+def get_redis_queue(name: str):
     redis = Redis(host=os.getenv("REDIS_HOST"), password=os.getenv("REDIS_PASSWORD"))
-    queue = Queue(name="nomenclature", connection=redis)
+    queue = Queue(name=name, connection=redis)
     return queue
 
 

--- a/src/infra/redis_queue.py
+++ b/src/infra/redis_queue.py
@@ -8,6 +8,12 @@ from rq.queue import Queue
 MAX_JOB_TIMEOUT = 60 * 60 * 24
 
 
+class QueueName:
+    MAPPING = "mapping_nomenclatures"
+    SYNCING = "sync_nomenclatures"
+    RETRAINING = "retrain_classifier"
+
+
 def get_redis_queue(name: str):
     redis = Redis(host=os.getenv("REDIS_HOST"), password=os.getenv("REDIS_PASSWORD"))
     queue = Queue(name=name, connection=redis)

--- a/src/model/retrain_classifier_model.py
+++ b/src/model/retrain_classifier_model.py
@@ -15,7 +15,7 @@ from sqlmodel import Session
 from tqdm import tqdm
 
 from infra.database import engine
-from infra.redis_queue import get_redis_queue, MAX_JOB_TIMEOUT, get_job
+from infra.redis_queue import get_redis_queue, MAX_JOB_TIMEOUT, get_job, QueueName
 from repository.classifier_version_repository import _delete_classifier_version_in_db, _get_classifier_versions
 from scheme.classifier_scheme import ClassifierVersion, ClassifierVersionRead, ClassifierRetrainingResult, \
     SyncClassifierVersionPatch
@@ -277,7 +277,7 @@ def _retrain_classifier(
 
 
 def start_classifier_retraining(db_con_str: str, table_name: str) -> JobIdRead:
-    queue = get_redis_queue()
+    queue = get_redis_queue(name=QueueName.RETRAINING)
     job = queue.enqueue(
         _retrain_classifier,
         db_con_str,

--- a/src/model/synchronize_nomenclatures_model.py
+++ b/src/model/synchronize_nomenclatures_model.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 
 from infra.chroma_store import is_in_vectorstore, \
     connect_to_chroma_collection, update_collection_with_patch
-from infra.redis_queue import get_redis_queue, MAX_JOB_TIMEOUT, get_job
+from infra.redis_queue import get_redis_queue, MAX_JOB_TIMEOUT, get_job, QueueName
 from scheme.nomenclature_scheme import SyncNomenclaturesChromaPatch, MsuDatabaseOneNomenclatureRead, JobIdRead, \
     SyncOneNomenclatureDataRead, SyncNomenclaturesResultRead
 
@@ -118,7 +118,7 @@ def start_synchronizing_nomenclatures(
     chroma_collection_name: str,
     sync_period: int,
 ):
-    queue = get_redis_queue()
+    queue = get_redis_queue(name=QueueName.SYNCING)
     job = queue.enqueue(
         synchronize_nomenclatures,
         nom_db_con_str,


### PR DESCRIPTION
## Выполнено
- Пофиксил функцию создания очереди редиса, теперь в неё передаётся название очереди
- Добавил список названий всех очередей редиса
- Разделил задачи по синхронизации, маппингу и переобучению на разные очереди